### PR TITLE
Rework release.sh to two-step PR-friendly flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ claude.out
 # Kartoza Brand Asset Pack — versioned by Kartoza, copied into docs/assets
 # on demand. The folder itself is not part of this project's history.
 Kartoza_Brand_Assets_v0_1/
+
+# Claude Code session metadata (transcripts, local settings)
+.claude/

--- a/docs/about/specification.md
+++ b/docs/about/specification.md
@@ -116,16 +116,29 @@ does not have a preceding `-- Issue #NNN:` line in the file.
 
 ### 5.1 Local release script
 
-`scripts/release.sh --bump <major|minor|patch> [--commit]`:
+`scripts/release.sh` runs in two modes because `main` is protected
+(direct pushes are rejected — releases must land via PR).
 
-1. Reads `VERSION`, computes the next version.
-2. Requires that at least one of the two `UNRELEASED.sql` files contain a
+**Mode A — `--bump <major|minor|patch> --commit [--empty]`:**
+
+1. Refuses to run unless on a clean `main` that matches `origin/main`.
+2. Reads `VERSION`, computes the next version `X.Y.Z`.
+3. Requires that at least one of the two `UNRELEASED.sql` files contain a
    `-- Issue #` block (override with `--empty`).
-3. `git mv` both `UNRELEASED.sql` → `vX.Y.Z.sql`.
-4. Recreates empty `UNRELEASED.sql` files (header preserved).
-5. Writes new version into `VERSION`.
-6. Regenerates per-component schema reference docs.
-7. With `--commit`, creates the release commit and the `vX.Y.Z` git tag.
+4. Creates a release branch `release/vX.Y.Z`.
+5. `git mv` both `UNRELEASED.sql` → `vX.Y.Z.sql`.
+6. Recreates empty `UNRELEASED.sql` files (header preserved).
+7. Writes new version into `VERSION`.
+8. Regenerates per-component schema reference docs under `docs/data-model/`.
+9. Commits everything as `Release vX.Y.Z`, pushes the branch, opens a PR
+   via `gh pr create`.
+
+**Mode B — `--tag` (no `--bump`):**
+
+1. Refuses to run unless on `main` at `origin/main`.
+2. Reads `VERSION` (now `X.Y.Z` from the merged PR).
+3. Creates an annotated tag `vX.Y.Z` at `main` HEAD.
+4. Pushes the tag, which triggers `Release.yml`.
 
 ### 5.2 Release pipeline
 

--- a/docs/developer-guide/scripts.md
+++ b/docs/developer-guide/scripts.md
@@ -15,7 +15,7 @@ Every meaningful workflow has both a `scripts/<name>` entry point and a
 | `.#schema-diff` | `scripts/schema_diff.py` | Runs `migra` between two composite SQL bundles to produce a structured ALTER-style diff plus a Markdown summary. Used by the Artifacts and Release workflows. |
 | `.#migrate-pg` | `scripts/migrate_pg.sh` | Applies any `sql/migrations/pg/vX.Y.Z.sql` newer than `current_schema_version` against a target PG database. Strict-sequential, refuses downgrades. |
 | `.#migrate-gpkg` | `scripts/migrate_gpkg.py` | Same semantics as `migrate-pg`, but for an in-place GeoPackage. |
-| `.#release` | `scripts/release.sh` | Bumps `VERSION`, renames `UNRELEASED.sql` → `vX.Y.Z.sql` for both PG and GPKG, commits, tags. Needs `--bump patch\|minor\|major` and `--commit` to actually mutate. |
+| `.#release` | `scripts/release.sh` | Two-step release: `--bump patch\|minor\|major --commit` creates a `release/vX.Y.Z` branch + opens a PR (rotates `UNRELEASED.sql` → `vX.Y.Z.sql`, bumps `VERSION`, regenerates schema docs). After PR merge: `--tag` tags `main` HEAD and pushes the tag, which triggers `Release.yml`. |
 | `.#docs` | `scripts/generate_schema_docs.py` | Regenerates the per-component schema reference Markdown from a fresh reference PG database. Output goes under `docs/data-model/`. |
 
 ## QGIS launchers
@@ -78,7 +78,7 @@ Nothing stops you. From inside `nix develop`:
 ```bash
 ./scripts/build_gpkg.sh --crs EPSG:32735
 ./scripts/migrate_gpkg.py path/to/some.gpkg
-./scripts/release.sh --bump minor --dry-run
+./scripts/release.sh --bump minor --commit   # prepares branch + PR
 ```
 
 The `nix run .#…` wrappers exist for **cold-shell** usage &mdash; running

--- a/docs/schema-lifecycle/migrations.md
+++ b/docs/schema-lifecycle/migrations.md
@@ -96,10 +96,10 @@ Both behave identically:
    one, including a SHA-256 checksum of the file as applied.
 
 `UNRELEASED.sql` is **never** applied by the runners &mdash; it's
-work-in-progress, not a shipping migration. To preview pending changes
-locally, run `scripts/release.sh --bump patch --dry-run` to see what
-filename it would get, then either re-cut a build or run the SQL by hand
-in a throwaway database.
+work-in-progress, not a shipping migration. To preview pending changes,
+read `sql/migrations/{pg,gpkg}/UNRELEASED.sql` directly or run the SQL
+by hand against a throwaway database. The next release filename will be
+the bumped version (`VERSION` + the appropriate semver step).
 
 ## When in doubt: rebuild
 

--- a/docs/schema-lifecycle/release.md
+++ b/docs/schema-lifecycle/release.md
@@ -6,68 +6,102 @@ A release in Infrastructure Mapper is a *schema* release: it freezes the
 current `UNRELEASED.sql` migration into a versioned `vX.Y.Z.sql`, bumps
 `VERSION`, tags `main`, and publishes built artifacts.
 
-## `scripts/release.sh` &mdash; the cutover
+## `scripts/release.sh` &mdash; two-step cutover
+
+`main` is protected (PRs + status checks required), so the release
+flow is two steps:
 
 ```bash
+# Step 1: prepare the release branch + PR.
 nix run .#release -- --bump patch --commit
-nix run .#release -- --bump minor --commit
-nix run .#release -- --bump major --commit
+# (or --bump minor / --bump major)
+
+# After the PR has merged into main:
+git checkout main && git pull --ff-only
+
+# Step 2: tag the merged release commit.
+nix run .#release -- --tag
 ```
 
-The script does five things, in order:
+**Step 1 (`--commit`)** does the following on a fresh branch
+`release/vX.Y.Z`:
 
-1. **Validate**: refuses to run with a dirty working tree, on a non-main
-   branch, or if either `UNRELEASED.sql` is empty (no point bumping for
-   no schema change).
+1. **Validate**: refuses to run unless you're on a clean main that
+   matches `origin/main`. Refuses if either `UNRELEASED.sql` is empty
+   (no point bumping for no schema change) &mdash; pass `--empty` to
+   override (e.g. for a docs-only patch bump).
 2. **Bump `VERSION`**: reads the current semver, applies the requested
    bump, writes `MAJOR.MINOR.PATCH` back to the file.
 3. **Rename**: `sql/migrations/pg/UNRELEASED.sql` →
    `sql/migrations/pg/vX.Y.Z.sql`, and the same for `gpkg/`. Creates
    fresh empty `UNRELEASED.sql` files for the next cycle.
-4. **Commit**: a single commit titled
-   `Release vX.Y.Z` containing the `VERSION` bump and the renames.
-5. **Tag**: `git tag vX.Y.Z` on that commit.
+4. **Regenerate** the per-domain schema reference docs under
+   `docs/data-model/` (best-effort &mdash; needs Postgres reachable).
+5. **Commit + push**: a single `Release vX.Y.Z` commit on
+   `release/vX.Y.Z`, pushed to origin.
+6. **Open PR**: via `gh pr create`, base `main`, head `release/vX.Y.Z`.
 
-`--dry-run` prints what would happen without touching anything.
+**Step 2 (`--tag`)** runs on main *after* the PR has merged. It:
 
-`--commit` is required for the script to actually mutate state &mdash;
-without it, the dry-run path is the default. This is intentional belt-and-
-braces against accidental releases from a development shell.
+1. Verifies you're on `main` and at `origin/main`.
+2. Reads `VERSION` (which the merged PR has set to `X.Y.Z`).
+3. Creates an annotated tag `vX.Y.Z` at `main` HEAD.
+4. Pushes the tag.
+
+Pushing the tag triggers `.github/workflows/Release.yml`, which builds
+and publishes the artifacts.
+
+Why two steps: branch protection blocks direct pushes to `main`, so the
+release commit has to land via PR. The tag is just a pointer to the
+already-merged commit and doesn't go through branch protection, so it
+can be pushed directly. The `--tag` step also gives you a sanity gate
+between "PR is merged" and "Release.yml fires" &mdash; you can pause
+between the two if needed.
 
 ## The Release GitHub Action
 
-Pushing a `vX.Y.Z` tag to the remote triggers `.github/workflows/release.yml`,
-which builds and publishes:
+Pushing a `vX.Y.Z` tag triggers `.github/workflows/Release.yml`. It
+runs `scripts/build_artifacts.sh` and `scripts/schema_diff.py`, then
+attaches the full asset set to the GitHub release:
 
-| Artifact | What's in it |
+| Asset | What's in it |
 |---|---|
-| `infrastructure-mapper-vX.Y.Z-schema.tar.gz` | The full `sql/` tree at the tag (baseline + all migrations through vX.Y.Z). |
-| `infrastructure-mapper-vX.Y.Z.gpkg` | A canonical GeoPackage built fresh from the tag, in EPSG:4326. |
-| `infrastructure-mapper-vX.Y.Z-utm35s.gpkg` | The same data reprojected to EPSG:32735 (UTM Zone 35S) for southern Africa metric work. |
-| `CHANGELOG.md` extract | The release notes for `vX.Y.Z` parsed from `CHANGELOG.md`. |
+| `pg-schema-vX.Y.Z.sql` (+ `pg-schema-latest.sql`) | Composite SQL: extensions + meta + every domain + fixtures. |
+| `KartozaInfrastructureMapper-vX.Y.Z.gpkg` (+ `-latest.gpkg`) | Composite GeoPackage with every domain. |
+| `pg-schema-NN-name-vX.Y.Z.sql` (×13, + `-latest`) | Per-domain SQL slice. |
+| `KartozaInfrastructureMapper-NN-name-vX.Y.Z.gpkg` (×13, + `-latest`) | Per-domain GeoPackage. |
+| `pg-fixtures-vX.Y.Z.sql` (+ `-latest`) | Data-only dump of lookup tables. |
+| `pg-migrations-vX.Y.Z.tar.gz` (+ `-latest`) | Forward migration files + runner script. |
+| `gpkg-migrations-vX.Y.Z.tar.gz` (+ `-latest`) | Same, for GeoPackage. |
+| `schema-diff-vX.Y.Z.sql` (+ `-latest`) | `migra`-generated ALTER diff vs the previous release. |
+| `MANIFEST.json` | Byte sizes + per-domain table lists for every artifact. |
 
-Artifacts attach to the GitHub Release page automatically. Schema consumers
-can `curl` the tarball, or download a ready-to-use GeoPackage for the
-common metric CRS without rebuilding locally.
+Every asset is published twice: once with the version embedded (for
+reproducibility / archival) and once with `-latest` (so
+`https://github.com/kartoza/InfrastructureMapper/releases/latest/download/<name>`
+stable URLs resolve to the always-current file).
 
 ## Consuming a release
 
-For most users, the recommended consumption path is:
+For most users:
 
 ```bash
-# Download the canonical metric GeoPackage:
-gh release download vX.Y.Z --pattern '*-utm35s.gpkg'
+# Composite GeoPackage (everything, latest):
+curl -LO https://github.com/kartoza/InfrastructureMapper/releases/latest/download/KartozaInfrastructureMapper-latest.gpkg
 
-# Or, to apply the schema to an existing Postgres database:
-gh release download vX.Y.Z --pattern '*-schema.tar.gz'
-tar xf infrastructure-mapper-vX.Y.Z-schema.tar.gz
-psql -d my_db -f sql/0-meta.sql
-# … then the rest of the baseline + migrations in order.
+# Composite SQL (everything, latest):
+curl -LO https://github.com/kartoza/InfrastructureMapper/releases/latest/download/pg-schema-latest.sql
+psql -d my_db -v ON_ERROR_STOP=1 -f pg-schema-latest.sql
+
+# Just one domain (example: fencing):
+curl -LO https://github.com/kartoza/InfrastructureMapper/releases/latest/download/pg-schema-07-fencing-latest.sql
+curl -LO https://github.com/kartoza/InfrastructureMapper/releases/latest/download/KartozaInfrastructureMapper-07-fencing-latest.gpkg
 ```
 
-`scripts/migrate_pg.py` and `scripts/migrate_gpkg.py` can also pull a
-tarball directly &mdash; the runners just need access to the `sql/`
-directory tree.
+`scripts/migrate_pg.sh` and `scripts/migrate_gpkg.py` can apply the
+forward migrations from `pg-migrations-latest.tar.gz` /
+`gpkg-migrations-latest.tar.gz` on top of an existing earlier-version
+database.
 
 ## Why semver and not date-based versions
 

--- a/docs/schema-lifecycle/versioning.md
+++ b/docs/schema-lifecycle/versioning.md
@@ -24,8 +24,10 @@ Per the project's commit convention:
 | New feature, additive | minor (`0.1.0` → `0.2.0`) |
 | Breaking schema change | major (`0.1.0` → `1.0.0`) |
 
-`scripts/release.sh --bump patch|minor|major --commit` does the actual bump,
-file renames, and tag.
+`scripts/release.sh --bump patch|minor|major --commit` opens the release PR
+(file rename, `VERSION` bump, docs regenerate, branch push, PR via `gh`). A
+follow-up `scripts/release.sh --tag` on `main` after the PR merges creates
+and pushes the tag, triggering `Release.yml`.
 
 ## The `schema_migrations` table
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,46 +2,118 @@
 # SPDX-FileCopyrightText: Tim Sutton
 # SPDX-License-Identifier: MIT
 #
-# Cut a new release of the schema.
+# Cut a new release of the schema in two steps so the flow plays nicely
+# with branch protection rules that require PRs and status checks on
+# main:
 #
-# Steps:
-#   1. Read current VERSION; compute the next version from --bump.
-#   2. Verify UNRELEASED.sql files have something to release (or use --empty).
-#   3. Rename sql/migrations/{pg,gpkg}/UNRELEASED.sql -> vX.Y.Z.sql.
-#   4. Create fresh empty UNRELEASED.sql files.
-#   5. Write the new version into VERSION.
-#   6. Regenerate per-component schema reference docs.
-#   7. Commit and tag (only with --commit).
+#   1. scripts/release.sh --bump patch|minor|major --commit
+#        Prepares the release commit (rotates UNRELEASED.sql files,
+#        bumps VERSION, regenerates schema docs) on a new branch
+#        `release/vX.Y.Z`, pushes the branch, opens a PR.
+#
+#   2. After the PR has merged into main, run:
+#        scripts/release.sh --tag
+#        Tags main HEAD as vX.Y.Z (read from the committed VERSION
+#        file) and pushes the tag. Release.yml fires on the tag and
+#        publishes the release artifacts.
+#
+# Use `--empty` with `--commit` to allow a release when both
+# UNRELEASED.sql files contain no `-- Issue #NNN:` blocks (e.g. for a
+# docs-only patch bump).
 #
 # Usage:
-#   scripts/release.sh --bump patch|minor|major [--commit] [--empty]
-#
-# The GitHub Action on tag push then builds and publishes release artifacts.
+#   scripts/release.sh --bump patch|minor|major --commit [--empty]
+#   scripts/release.sh --tag
 
 set -euo pipefail
 
 BUMP=""
-DO_COMMIT=0
+MODE=""
 ALLOW_EMPTY=0
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --bump) BUMP="$2"; shift 2 ;;
         --bump=*) BUMP="${1#--bump=}"; shift ;;
-        --commit) DO_COMMIT=1; shift ;;
+        --commit) MODE="commit"; shift ;;
+        --tag) MODE="tag"; shift ;;
         --empty) ALLOW_EMPTY=1; shift ;;
-        -h|--help) sed -n '2,22p' "$0"; exit 0 ;;
+        -h|--help) sed -n '2,28p' "$0"; exit 0 ;;
         *) echo "Unknown arg: $1" >&2; exit 2 ;;
     esac
 done
 
-case "$BUMP" in
-    major|minor|patch) ;;
-    *) echo "ERROR: --bump must be major, minor, or patch." >&2; exit 2 ;;
-esac
+if [ -z "$MODE" ]; then
+    echo "ERROR: pick a mode: --commit (open release PR) or --tag (tag merged release)." >&2
+    exit 2
+fi
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
+
+# -----------------------------------------------------------------
+# Mode 2: --tag  — assumes the release PR has merged into main.
+# -----------------------------------------------------------------
+if [ "$MODE" = "tag" ]; then
+    if [ -n "$BUMP" ]; then
+        echo "ERROR: --bump is meaningless with --tag (version comes from VERSION)." >&2
+        exit 2
+    fi
+    CUR_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+    if [ "$CUR_BRANCH" != "main" ]; then
+        echo "ERROR: --tag must run on main (currently on $CUR_BRANCH)." >&2
+        exit 2
+    fi
+    echo ">> Fetching latest main..."
+    git fetch origin main
+    LOCAL="$(git rev-parse HEAD)"
+    REMOTE="$(git rev-parse origin/main)"
+    if [ "$LOCAL" != "$REMOTE" ]; then
+        echo "ERROR: local main ($LOCAL) is not at origin/main ($REMOTE)." >&2
+        echo "       git pull --ff-only first." >&2
+        exit 1
+    fi
+    VERSION="$(tr -d '[:space:]' < VERSION)"
+    VTAG="v$VERSION"
+    if git rev-parse "$VTAG" >/dev/null 2>&1; then
+        echo "ERROR: tag $VTAG already exists." >&2
+        echo "       To re-cut the release: git tag -d $VTAG && git push --delete origin $VTAG" >&2
+        exit 1
+    fi
+    echo ">> Tagging $VTAG at $(git rev-parse --short HEAD): $(git log -1 --pretty=%s)"
+    git tag -a "$VTAG" -m "Release $VTAG"
+    echo ">> Pushing tag..."
+    git push origin "$VTAG"
+    echo ">> Done. Release.yml will build artifacts and publish the GitHub release."
+    exit 0
+fi
+
+# -----------------------------------------------------------------
+# Mode 1: --commit  — prepare release branch + PR.
+# -----------------------------------------------------------------
+case "$BUMP" in
+    major|minor|patch) ;;
+    *) echo "ERROR: --commit requires --bump major|minor|patch." >&2; exit 2 ;;
+esac
+
+# Insist on starting from a clean main so the release branch is reproducible.
+CUR_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$CUR_BRANCH" != "main" ]; then
+    echo "ERROR: --commit must start from main (currently on $CUR_BRANCH)." >&2
+    exit 2
+fi
+if [ -n "$(git status --porcelain | grep -vE '^\?\?')" ]; then
+    echo "ERROR: working tree has staged or modified files; commit or stash first." >&2
+    exit 2
+fi
+echo ">> Fetching latest main..."
+git fetch origin main
+LOCAL="$(git rev-parse HEAD)"
+REMOTE="$(git rev-parse origin/main)"
+if [ "$LOCAL" != "$REMOTE" ]; then
+    echo "ERROR: local main is not at origin/main; git pull --ff-only first." >&2
+    exit 1
+fi
 
 CUR="$(tr -d '[:space:]' < VERSION)"
 IFS='.' read -r M N P <<< "$CUR"
@@ -54,13 +126,23 @@ esac
 
 NEW="$M.$N.$P"
 VNEW="v$NEW"
+BRANCH="release/$VNEW"
 
 echo ">> Current version: $CUR  →  New version: $NEW"
+echo ">> Release branch: $BRANCH"
+
+if git rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
+    echo "ERROR: branch $BRANCH already exists locally; delete it first." >&2
+    exit 1
+fi
+if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+    echo "ERROR: branch $BRANCH already exists on origin; delete it first." >&2
+    exit 1
+fi
 
 PG_UNREL=sql/migrations/pg/UNRELEASED.sql
 GPKG_UNREL=sql/migrations/gpkg/UNRELEASED.sql
 
-# Determine "has content" by checking if there is at least one Issue-annotated block.
 has_content() {
     grep -E '^[[:space:]]*--[[:space:]]*Issue[[:space:]]*#[0-9]+[[:space:]]*:' "$1" > /dev/null 2>&1
 }
@@ -74,6 +156,9 @@ if ! has_content "$PG_UNREL" && ! has_content "$GPKG_UNREL"; then
     echo ">> No migration content; releasing empty migration files."
 fi
 
+# Cut the release branch from current main HEAD.
+git checkout -b "$BRANCH"
+
 # Rename UNRELEASED -> vX.Y.Z and create new empty UNRELEASED stubs.
 HEADER_TEMPLATE_PG=$(head -20 "$PG_UNREL" | grep -E '^--' | head -20)
 HEADER_TEMPLATE_GPKG=$(head -25 "$GPKG_UNREL" | grep -E '^--' | head -25)
@@ -81,7 +166,6 @@ HEADER_TEMPLATE_GPKG=$(head -25 "$GPKG_UNREL" | grep -E '^--' | head -25)
 git mv "$PG_UNREL" "sql/migrations/pg/$VNEW.sql"
 git mv "$GPKG_UNREL" "sql/migrations/gpkg/$VNEW.sql"
 
-# Recreate empty UNRELEASED.sql with the previous header preserved.
 {
     printf '%s\n' "$HEADER_TEMPLATE_PG"
 } > "$PG_UNREL"
@@ -94,7 +178,7 @@ echo "$NEW" > VERSION
 echo ">> Renamed UNRELEASED.sql → $VNEW.sql"
 echo ">> Wrote VERSION=$NEW"
 
-# Refresh docs (best-effort; needs PG running).
+# Regenerate schema reference docs (best-effort; needs Postgres running).
 if command -v psql >/dev/null && pg_isready -h "${PGHOST:-$ROOT/pgdata}" -p "${PGPORT:-5432}" -q 2>/dev/null; then
     echo ">> Regenerating schema reference docs..."
     .venv/bin/python scripts/generate_schema_docs.py || {
@@ -104,11 +188,50 @@ else
     echo ">> Skipping doc regeneration (Postgres not reachable)."
 fi
 
-if [ "$DO_COMMIT" = 1 ]; then
-    git add VERSION "$PG_UNREL" "$GPKG_UNREL" "sql/migrations/pg/$VNEW.sql" "sql/migrations/gpkg/$VNEW.sql" sql/*.md
-    git commit -m "Release $VNEW"
-    git tag -a "$VNEW" -m "Release $VNEW"
-    echo ">> Committed and tagged $VNEW. Push with: git push && git push --tags"
+# Stage everything that legitimately belongs in the release commit. The
+# regenerated docs live under docs/data-model/ (not sql/ as in the
+# pre-mkdocs layout); include them so the release commit + the
+# subsequent pre-push schema-reference hook agree on what's on disk.
+git add VERSION \
+    "$PG_UNREL" "$GPKG_UNREL" \
+    "sql/migrations/pg/$VNEW.sql" "sql/migrations/gpkg/$VNEW.sql" \
+    docs/data-model/*.md
+
+git commit -m "Release $VNEW"
+
+echo ">> Pushing $BRANCH..."
+git push -u origin "$BRANCH"
+
+# Open the PR via gh CLI. Falls back to printing the compare URL if gh
+# isn't available or authenticated.
+PR_BODY=$(cat <<EOF
+Release $VNEW.
+
+- Rotates \`sql/migrations/{pg,gpkg}/UNRELEASED.sql\` to \`$VNEW.sql\`
+  (frozen, immutable from here on).
+- Bumps \`VERSION\` to \`$NEW\`.
+- Refreshes per-domain schema reference docs.
+
+Once this PR merges, run \`scripts/release.sh --tag\` on \`main\` to
+tag $VNEW and trigger the Release workflow.
+EOF
+)
+
+if command -v gh >/dev/null 2>&1; then
+    echo ">> Opening pull request..."
+    if gh pr create --base main --head "$BRANCH" \
+        --title "Release $VNEW" --body "$PR_BODY" 2>&1; then
+        :
+    else
+        echo "WARNING: gh pr create failed. Open it manually." >&2
+    fi
 else
-    echo ">> Skipping commit (pass --commit to commit and tag in one step)."
+    REPO_URL="$(git config --get remote.origin.url | sed -E 's|git@github.com:|https://github.com/|; s|\.git$||')"
+    echo ">> Open PR manually: $REPO_URL/compare/main...$BRANCH"
 fi
+
+echo
+echo ">> Release $VNEW prepared on branch $BRANCH."
+echo ">> After the PR merges to main:"
+echo ">>     git checkout main && git pull --ff-only"
+echo ">>     scripts/release.sh --tag"

--- a/scripts/welcome.sh
+++ b/scripts/welcome.sh
@@ -105,7 +105,7 @@ row "nix run .#schema-diff"     "migra diff between two composite SQL bundles"
 row "nix run .#migrate-pg"      "Apply pending PG migrations to a target DB"
 row "nix run .#migrate-gpkg"    "Apply pending GPKG migrations to a target file"
 row "nix run .#docs"            "Regenerate Schema Reference in docs/data-model/*.md"
-row "nix run .#release"         "Cut a release (--bump patch|minor|major --commit)"
+row "nix run .#release"         "Cut a release: --bump X --commit (PR), then --tag after merge"
 
 section "📚" "Documentation site (mkdocs-material)"
 row "nix run .#docs-serve"   "Live preview at http://127.0.0.1:8000"


### PR DESCRIPTION
## Summary

Rewrites `scripts/release.sh` so it works with branch protection on
`main` (which rejects direct pushes — that's what stranded the
v0.2.0 release flow yesterday).

New two-step flow:

```bash
# Step 1: prepares the release commit on a new branch + opens a PR.
nix run .#release -- --bump minor --commit

# After the PR has merged:
git checkout main && git pull --ff-only

# Step 2: tag main HEAD; Release.yml fires on the tag.
nix run .#release -- --tag
```

Also fixes the git-add path bug: `release.sh` was adding `sql/*.md`
but the regenerated docs live under `docs/data-model/*.md` since
the mkdocs migration. That mismatch is what left the v0.2.0
release commit with unstaged regenerated docs and made the
pre-push hook reject the push.

`.gitignore` excludes `.claude/` so REUSE stops flagging Claude
Code session metadata.

Docs (`schema-lifecycle/release.md`, `versioning.md`, `migrations.md`,
`developer-guide/scripts.md`, `about/specification.md`, welcome
banner) describe the new flow and the artifact set
(per-domain slices, schema diff, `-latest` companions) that
v0.2.0 Release.yml shipped.

## Test plan

- [x] `mkdocs build --strict` passes
- [x] `scripts/release.sh --help` shows the two-mode usage
- [ ] CI green on this PR
- [ ] Next release uses the new flow end-to-end