### PR TITLE
Fix schema-diff base-bundle glob picking per-domain slice

### DIFF
--- a/.github/workflows/Artifacts.yml
+++ b/.github/workflows/Artifacts.yml
@@ -131,9 +131,12 @@ jobs:
         if: steps.ver.outputs.base_sha != ''
         run: |
           set -euo pipefail
-          # Bundles are produced by build_artifacts.sh with predictable names;
-          # globbing them via find avoids shellcheck SC2012 (ls parsing).
-          BASE_BUNDLE="$(find dist-base -maxdepth 1 -name 'pg-schema-*.sql' -print -quit)"
+          # Use explicit filenames — `find ... pg-schema-*.sql -print -quit`
+          # also matched per-domain slices (pg-schema-11-poles-*.sql etc.)
+          # and could non-deterministically pick a slice as the "base
+          # bundle", which then failed to load because its FK targets live
+          # in other domains.
+          BASE_BUNDLE="dist-base/pg-schema-${{ steps.ver.outputs.base_label }}.sql"
           HEAD_BUNDLE="dist/pg-schema-${{ steps.ver.outputs.head_ver }}.sql"
           nix develop --command python3 scripts/schema_diff.py \
             --base-bundle "$BASE_BUNDLE" \

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -79,7 +79,10 @@ jobs:
         if: steps.ver.outputs.prev_tag != ''
         run: |
           set -euo pipefail
-          BASE_BUNDLE="$(find dist-prev -maxdepth 1 -name 'pg-schema-*.sql' -print -quit)"
+          # Explicit filenames; pg-schema-*.sql also matches per-domain
+          # slices (pg-schema-NN-name-*.sql), so a glob can pick a slice
+          # that lacks cross-domain FK targets and fail to load.
+          BASE_BUNDLE="dist-prev/pg-schema-${{ steps.ver.outputs.prev_tag }}.sql"
           HEAD_BUNDLE="dist/pg-schema-${{ steps.ver.outputs.tag }}.sql"
           nix develop --command python3 scripts/schema_diff.py \
             --base-bundle "$BASE_BUNDLE" \


### PR DESCRIPTION
## Summary

`Artifacts.yml` and `Release.yml` both selected the schema-diff base
bundle with:

```bash
BASE_BUNDLE="$(find dist-base -maxdepth 1 -name 'pg-schema-*.sql' -print -quit)"
```

The `pg-schema-*.sql` glob matches *both* the composite
(`pg-schema-VERSION.sql`) and every per-domain slice
(`pg-schema-NN-name-VERSION.sql`). `find -print -quit` then picked a
non-deterministic first match — in PR #65's CI run that was
`pg-schema-11-poles-base-XXX.sql`.

Per-domain slices ship the extensions + meta layer + that domain's
tables + that domain's fixtures, but cross-domain foreign keys aren't
included by design (e.g. `pole_conditions` foreign-keys `condition`
which lives in `sql/5-monitoring.sql`). Loading a slice in isolation
fails with `relation "condition" does not exist` — exactly what PR
#65's CI hit.

Fix: address the composite by exact filename in both workflows.

## Test plan

- [x] `actionlint` clean
- [x] Local repro of `build_artifacts.sh` confirms the per-domain
      slices themselves aren't broken; only the workflow's selection of
      which bundle to diff was wrong
- [ ] CI green on this PR
- [ ] After merge, retrigger PR #65 and confirm it now goes green