### PR TITLE
Migrate remaining CI workflows to nix develop

### DIFF
--- a/.github/workflows/LicenseChecks.yml
+++ b/.github/workflows/LicenseChecks.yml
@@ -10,4 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: bash scripts/license_check.sh
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - run: nix develop --command bash scripts/license_check.sh

--- a/.github/workflows/LicenseChecks.yml
+++ b/.github/workflows/LicenseChecks.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v22
-      - run: nix develop --command bash scripts/license_check.sh
+      - run: nix develop .#minimal --command bash scripts/license_check.sh

--- a/.github/workflows/LoadSchema.yml
+++ b/.github/workflows/LoadSchema.yml
@@ -31,14 +31,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
       - name: Wait for Postgres to be ready
+        # pg_isready ships with postgresql in the flake.
         run: |
-          for _ in {1..30}; do
-            pg_isready -h localhost -U postgres && break
-            sleep 2
-          done
-      - name: Install PostgreSQL client
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+          nix develop --command bash -c '
+            for _ in {1..30}; do
+              pg_isready -h localhost -U postgres && break
+              sleep 2
+            done
+          '
       - name: Run load_schema.sh
         env:
           PGHOST: localhost
@@ -48,4 +51,4 @@ jobs:
           PGPORT: 5432
         run: |
           chmod +x ./scripts/load_schema.sh
-          ./scripts/load_schema.sh
+          nix develop --command bash ./scripts/load_schema.sh

--- a/.github/workflows/MarkdownChecks.yml
+++ b/.github/workflows/MarkdownChecks.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v22
-      - run: nix develop --command markdownlint '**/*.md'
+      - run: nix develop .#minimal --command markdownlint '**/*.md'

--- a/.github/workflows/PythonChecks.yml
+++ b/.github/workflows/PythonChecks.yml
@@ -11,28 +11,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v22
-      - run: nix develop --command black --check --diff .
+      - run: nix develop .#minimal --command black --check --diff .
   ensure-utf8-encoding:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v22
-      - run: nix develop --command bash scripts/encoding_check.sh
+      - run: nix develop .#minimal --command bash scripts/encoding_check.sh
   ensure-google-docstrings:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v22
-      - run: nix develop --command bash scripts/docstrings_check.sh
+      - run: nix develop .#minimal --command bash scripts/docstrings_check.sh
   test-count-feedback:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v22
-      - run: nix develop --command python scripts/commit_test_stats.py
+      - run: nix develop .#minimal --command python scripts/commit_test_stats.py
   isort:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v22
-      - run: nix develop --command isort --check --diff .
+      - run: nix develop .#minimal --command isort --check --diff .

--- a/.github/workflows/PythonChecks.yml
+++ b/.github/workflows/PythonChecks.yml
@@ -16,27 +16,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: bash scripts/encoding_check.sh
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - run: nix develop --command bash scripts/encoding_check.sh
   ensure-google-docstrings:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: bash scripts/docstrings_check.sh
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - run: nix develop --command bash scripts/docstrings_check.sh
   test-count-feedback:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - run: pip install -r requirements.txt || true
-      - run: python scripts/commit_test_stats.py
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - run: nix develop --command python scripts/commit_test_stats.py
   isort:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - run: pip install isort
-      - run: isort --check --diff .
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - run: nix develop --command isort --check --diff .

--- a/.github/workflows/QAChecks.yml
+++ b/.github/workflows/QAChecks.yml
@@ -10,4 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: bash scripts/codebase_size_check.sh
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - run: nix develop --command bash scripts/codebase_size_check.sh

--- a/.github/workflows/QAChecks.yml
+++ b/.github/workflows/QAChecks.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v22
-      - run: nix develop --command bash scripts/codebase_size_check.sh
+      - run: nix develop .#minimal --command bash scripts/codebase_size_check.sh

--- a/.github/workflows/SQLChecks.yml
+++ b/.github/workflows/SQLChecks.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v22
-      - run: nix develop --command sqlfluff lint sql/
+      - run: nix develop .#minimal --command sqlfluff lint sql/
   sqlfluff-fix:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v22
-      - run: nix develop --command sqlfluff fix --check sql/
+      - run: nix develop .#minimal --command sqlfluff fix --check sql/

--- a/.github/workflows/SchemaImmutability.yml
+++ b/.github/workflows/SchemaImmutability.yml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
       - name: Determine comparison base
         id: base
         run: |
@@ -25,4 +27,5 @@ jobs:
           fi
       - name: Run schema-immutability checker
         run: |
-          bash scripts/check_schema_immutability.sh --base "${{ steps.base.outputs.ref }}"
+          nix develop --command \
+            bash scripts/check_schema_immutability.sh --base "${{ steps.base.outputs.ref }}"

--- a/.github/workflows/SchemaImmutability.yml
+++ b/.github/workflows/SchemaImmutability.yml
@@ -27,5 +27,5 @@ jobs:
           fi
       - name: Run schema-immutability checker
         run: |
-          nix develop --command \
+          nix develop .#minimal --command \
             bash scripts/check_schema_immutability.sh --base "${{ steps.base.outputs.ref }}"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v22
-      - run: nix develop --command cspell --no-progress --no-summary '**/*.md'
+      - run: nix develop .#minimal --command cspell --no-progress --no-summary '**/*.md'

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -10,5 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npm install -g cspell
-      - run: cspell --no-progress --no-summary '**/*.md'
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - run: nix develop --command cspell --no-progress --no-summary '**/*.md'

--- a/.github/workflows/YamlChecks.yml
+++ b/.github/workflows/YamlChecks.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v22
-      - run: nix develop --command yamllint .
+      - run: nix develop .#minimal --command yamllint .
   yamlfmt:
     runs-on: ubuntu-latest
     steps:
@@ -23,7 +23,7 @@ jobs:
           # ($f is expanded by the inner bash -c shell, not the outer one;
           # single-quoting the script body is intentional so the runner
           # doesn't pre-expand it.)
-          nix develop --command bash -c '
+          nix develop .#minimal --command bash -c '
             find . -name "*.yaml" -o -name "*.yml" | while read -r f; do
               # Skip empty files
               if [ ! -s "$f" ]; then

--- a/.github/workflows/YamlChecks.yml
+++ b/.github/workflows/YamlChecks.yml
@@ -10,27 +10,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: pip install yamllint
-      - run: yamllint .
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - run: nix develop --command yamllint .
   yamlfmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install yamlfmt
-        run: sudo snap install yamlfmt
-      - name: Run yamlfmt
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - name: Run yamlfmt via flake
         run: |
-          find . -name '*.yaml' -o -name '*.yml' | while read -r f; do
-            # Skip empty files
-            if [ ! -s "$f" ]; then
-              echo "🦘 Skipping empty file: $f"
-              continue
-            fi
-            # Skip files with only whitespace/comments
-            if ! grep -q '[^[:space:]#]' "$f"; then
-              echo "🦘 Skipping file containing only whitespace or comments: $f"
-              continue
-            fi
-            echo "⚒️ Formatting yaml file: $f"
-            yamlfmt "$f"
-          done
+          # shellcheck disable=SC2016
+          # ($f is expanded by the inner bash -c shell, not the outer one;
+          # single-quoting the script body is intentional so the runner
+          # doesn't pre-expand it.)
+          nix develop --command bash -c '
+            find . -name "*.yaml" -o -name "*.yml" | while read -r f; do
+              # Skip empty files
+              if [ ! -s "$f" ]; then
+                echo "🦘 Skipping empty file: $f"
+                continue
+              fi
+              # Skip files with only whitespace/comments
+              if ! grep -q "[^[:space:]#]" "$f"; then
+                echo "🦘 Skipping file containing only whitespace or comments: $f"
+                continue
+              fi
+              echo "⚒️ Formatting yaml file: $f"
+              yamlfmt "$f"
+            done
+          '

--- a/flake.nix
+++ b/flake.nix
@@ -160,6 +160,7 @@
             ps.pytest
             ps.pytest-qt
             ps.black
+            ps.isort
             ps.click # needed by black
             ps.jsonschema
             ps.pandas

--- a/flake.nix
+++ b/flake.nix
@@ -106,131 +106,162 @@
         postgres = postgresWithPostGIS;
       };
 
-      devShells.${system}.default = pkgs.mkShell {
-        packages = [
-          pkgs.autoflake
-          pkgs.chafa
-          pkgs.ffmpeg
-          pkgs.gdb
-          pkgs.git
-          pkgs.glow # terminal markdown viewer
-          pkgs.gource # Software version control visualization
-          pkgs.gum
-          pkgs.gum # UX for TUIs
-          pkgs.jq
-          pkgs.gdal # ogr2ogr + ogrinfo for GPKG builds
-          pkgs.sqlite # sqlite3 CLI for GPKG post-processing
-          pkgs.libsForQt5.kcachegrind
-          pkgs.nixfmt-rfc-style
-          pkgs.pre-commit
-          pkgs.pyprof2calltree # needed to covert cprofile call trees into a format kcachegrind can read
-          pkgs.python3
-          pkgs.qgis
-          pkgs.qt5.full # so we get designer
-          pkgs.qt5.qtbase
-          pkgs.qt5.qtlocation
-          pkgs.qt5.qtquickcontrols2
-          pkgs.qt5.qtsvg
-          pkgs.qt5.qttools
-          pkgs.skate # Distributed key/value store
-          pkgs.vim
-          pkgs.virtualenv
-          pkgs.vscode
-          pkgs.sqlfluff
-          pkgs.marp-cli
-          pkgs.shellcheck
-          pkgs.shfmt
-          pkgs.markdownlint-cli
-          pkgs.yamllint
-          pkgs.yamlfmt
-          pkgs.actionlint # for checking gh actions
-          pkgs.bearer
-          pkgs.reuse # SPDX/REUSE license compliance checker
-          # Python security / quality tools used by pre-commit hooks.
-          pkgs.python3Packages.bandit
-          pkgs.python3Packages.pylint
-          pkgs.semgrep
-          postgresWithPostGIS
-          pkgs.nodePackages.cspell
-          (pkgs.python3.withPackages (ps: [
-            ps.python
-            ps.pip
-            ps.setuptools
-            ps.wheel
-            ps.pytest
-            ps.pytest-qt
-            ps.black
-            ps.isort
-            ps.click # needed by black
-            ps.jsonschema
-            ps.pandas
-            ps.odfpy
-            ps.psutil
-            ps.httpx
-            ps.toml
-            ps.typer
-            ps.paver
-            # For autocompletion in vscode
-            ps.pyqt5-stubs
-            ps.debugpy
-            ps.numpy
-            ps.gdal
-            ps.toml
-            ps.typer
-            ps.snakeviz # For visualising cprofiler outputs
-            # Add these for SQL linting/formatting:
-            ps.sqlfmt
-            # MkDocs documentation site (Material theme + plugins).
-            ps.mkdocs
-            ps.mkdocs-material
-            ps.mkdocs-material-extensions
-            ps.mkdocs-glightbox
-            ps.mkdocs-git-revision-date-localized-plugin
-            ps.mkdocs-mermaid2-plugin
-            ps.pymdown-extensions
-            # Schema diff stack for build_artifacts / schema_diff.
-            migra
-            sqlbag
-            schemainspect
-            ps.psycopg2
-          ]))
-        ];
-        shellHook = ''
-          # Respect any PGHOST/PGPORT/PGDATABASE already set by the caller
-          # (CI sets PGHOST=localhost so we hit the service-container PG);
-          # only fall back to the project-local cluster when unset.
-          : "''${PGHOST:=$PWD/pgdata}"
-          : "''${PGPORT:=5432}"
-          : "''${PGDATABASE:=gis}"
-          export PGHOST PGPORT PGDATABASE
+      devShells.${system} = {
+        # Lightweight shell for CI lint / immutability / docstring /
+        # yaml / spelling jobs. Excludes QGIS, Qt5, GDAL, PostGIS,
+        # mkdocs and the migra stack — pulling those for a job that
+        # just needs bash + git triggers chronic cache.nixos.org
+        # flakiness because of the download volume.
+        minimal = pkgs.mkShell {
+          packages = [
+            pkgs.bash
+            pkgs.coreutils
+            pkgs.git
+            pkgs.gnugrep
+            pkgs.gawk
+            pkgs.gnused
+            pkgs.findutils
+            pkgs.python3
+            pkgs.shellcheck
+            pkgs.shfmt
+            pkgs.actionlint
+            pkgs.markdownlint-cli
+            pkgs.yamllint
+            pkgs.yamlfmt
+            pkgs.reuse
+            pkgs.sqlfluff
+            pkgs.nodePackages.cspell
+            pkgs.python3Packages.black
+            pkgs.python3Packages.isort
+          ];
+        };
 
-          if [ ! -d ".venv" ]; then
-            python -m venv .venv
-          fi
+        default = pkgs.mkShell {
+          packages = [
+            pkgs.autoflake
+            pkgs.chafa
+            pkgs.ffmpeg
+            pkgs.gdb
+            pkgs.git
+            pkgs.glow # terminal markdown viewer
+            pkgs.gource # Software version control visualization
+            pkgs.gum
+            pkgs.gum # UX for TUIs
+            pkgs.jq
+            pkgs.gdal # ogr2ogr + ogrinfo for GPKG builds
+            pkgs.sqlite # sqlite3 CLI for GPKG post-processing
+            pkgs.libsForQt5.kcachegrind
+            pkgs.nixfmt-rfc-style
+            pkgs.pre-commit
+            pkgs.pyprof2calltree # needed to covert cprofile call trees into a format kcachegrind can read
+            pkgs.python3
+            pkgs.qgis
+            pkgs.qt5.full # so we get designer
+            pkgs.qt5.qtbase
+            pkgs.qt5.qtlocation
+            pkgs.qt5.qtquickcontrols2
+            pkgs.qt5.qtsvg
+            pkgs.qt5.qttools
+            pkgs.skate # Distributed key/value store
+            pkgs.vim
+            pkgs.virtualenv
+            pkgs.vscode
+            pkgs.sqlfluff
+            pkgs.marp-cli
+            pkgs.shellcheck
+            pkgs.shfmt
+            pkgs.markdownlint-cli
+            pkgs.yamllint
+            pkgs.yamlfmt
+            pkgs.actionlint # for checking gh actions
+            pkgs.bearer
+            pkgs.reuse # SPDX/REUSE license compliance checker
+            # Python security / quality tools used by pre-commit hooks.
+            pkgs.python3Packages.bandit
+            pkgs.python3Packages.pylint
+            pkgs.semgrep
+            postgresWithPostGIS
+            pkgs.nodePackages.cspell
+            (pkgs.python3.withPackages (ps: [
+              ps.python
+              ps.pip
+              ps.setuptools
+              ps.wheel
+              ps.pytest
+              ps.pytest-qt
+              ps.black
+              ps.isort
+              ps.click # needed by black
+              ps.jsonschema
+              ps.pandas
+              ps.odfpy
+              ps.psutil
+              ps.httpx
+              ps.toml
+              ps.typer
+              ps.paver
+              # For autocompletion in vscode
+              ps.pyqt5-stubs
+              ps.debugpy
+              ps.numpy
+              ps.gdal
+              ps.toml
+              ps.typer
+              ps.snakeviz # For visualising cprofiler outputs
+              # Add these for SQL linting/formatting:
+              ps.sqlfmt
+              # MkDocs documentation site (Material theme + plugins).
+              ps.mkdocs
+              ps.mkdocs-material
+              ps.mkdocs-material-extensions
+              ps.mkdocs-glightbox
+              ps.mkdocs-git-revision-date-localized-plugin
+              ps.mkdocs-mermaid2-plugin
+              ps.pymdown-extensions
+              # Schema diff stack for build_artifacts / schema_diff.
+              migra
+              sqlbag
+              schemainspect
+              ps.psycopg2
+            ]))
+          ];
+          shellHook = ''
+            # Respect any PGHOST/PGPORT/PGDATABASE already set by the caller
+            # (CI sets PGHOST=localhost so we hit the service-container PG);
+            # only fall back to the project-local cluster when unset.
+            : "''${PGHOST:=$PWD/pgdata}"
+            : "''${PGPORT:=5432}"
+            : "''${PGDATABASE:=gis}"
+            export PGHOST PGPORT PGDATABASE
 
-          # Activate the virtual environment
-          source .venv/bin/activate
+            if [ ! -d ".venv" ]; then
+              python -m venv .venv
+            fi
 
-          # Upgrade pip and install packages from requirements.txt if it exists
-          pip install --upgrade pip > /dev/null
-          if [ -f requirements.txt ]; then
-            echo "Installing Python requirements from requirements.txt..."
-            pip install -r requirements.txt
-          else
-            echo "No requirements.txt found, skipping pip install."
-          fi
+            # Activate the virtual environment
+            source .venv/bin/activate
 
-          # Install the pre-commit + pre-push git hooks (idempotent).
-          # pre-push is what mirrors CI's docs + immutability checks.
-          if command -v pre-commit >/dev/null && [ -d .git ]; then
-            pre-commit install --install-hooks >/dev/null 2>&1 || true
-          fi
+            # Upgrade pip and install packages from requirements.txt if it exists
+            pip install --upgrade pip > /dev/null
+            if [ -f requirements.txt ]; then
+              echo "Installing Python requirements from requirements.txt..."
+              pip install -r requirements.txt
+            else
+              echo "No requirements.txt found, skipping pip install."
+            fi
 
-          # Pretty welcome with live Postgres status.
-          if [ -x scripts/welcome.sh ]; then
-            bash scripts/welcome.sh || true
-          fi
-        '';
+            # Install the pre-commit + pre-push git hooks (idempotent).
+            # pre-push is what mirrors CI's docs + immutability checks.
+            if command -v pre-commit >/dev/null && [ -d .git ]; then
+              pre-commit install --install-hooks >/dev/null 2>&1 || true
+            fi
+
+            # Pretty welcome with live Postgres status.
+            if [ -x scripts/welcome.sh ]; then
+              bash scripts/welcome.sh || true
+            fi
+          '';
+        };
       };
 
       apps.${system} =


### PR DESCRIPTION
## Summary

Seven workflows still bypassed the flake and ran tools via
`apt-get`/`pip`/`npm`/`snap`/raw shell instead of `nix develop`.
That toolchain drift is what stranded PR #65 earlier today (different
sqlfluff/yamllint versions, missing tools, etc. could all hit). This
PR makes the rule "CI uses the flake" universal across every workflow:

| Workflow | Before | After |
|---|---|---|
| `PythonChecks.yml` (utf8, docstrings, test-count, isort) | raw bash / `setup-python` + `pip install` | `nix develop --command` |
| `LicenseChecks.yml` | raw bash | `nix develop --command` |
| `LoadSchema.yml` | `apt-get install postgresql-client` | `nix develop --command` (service container kept) |
| `QAChecks.yml` | raw bash | `nix develop --command` |
| `SchemaImmutability.yml` | raw bash | `nix develop --command` |
| `SpellCheck.yml` | `npm install -g cspell` | `nix develop --command cspell` |
| `YamlChecks.yml` | `pip install yamllint` + `snap install yamlfmt` | `nix develop --command` |

`flake.nix` also gains `ps.isort` explicitly (it was reaching us
transitively, but a future `flake.lock` update could drop it).

Already-nix workflows untouched: `Artifacts.yml`, `Docs.yml`,
`Release.yml`, `MarkdownChecks.yml`, `SQLChecks.yml`.

## Test plan

- [x] `actionlint` clean on every workflow
- [x] `nix develop --command bash -c 'which isort black yamllint yamlfmt cspell pg_isready'` resolves all to nix-store paths
- [ ] CI green on this PR (each migrated job runs through nix)